### PR TITLE
fix(CBP-48903): Fix Run Fail Issue Commit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
       run: |
         find $CLOUDBEES_WORKSPACE/store -mindepth 2 -maxdepth 2 \
           -type d ! -name "discovered-profile-findings" \
-          -exec rm -rf {} +
+          -exec rm -rf {} + 2>/dev/null || true
         rm -rf $CLOUDBEES_WORKSPACE/store/binary-assets
         rm -rf $CLOUDBEES_WORKSPACE/store/request
 

--- a/action.yml
+++ b/action.yml
@@ -38,11 +38,13 @@ runs:
       uses: docker://alpine:latest
       shell: sh
       run: |
-        find $CLOUDBEES_WORKSPACE/store -mindepth 2 -maxdepth 2 \
-          -type d ! -name "discovered-profile-findings" \
-          -exec rm -rf {} + 2>/dev/null || true
-        rm -rf $CLOUDBEES_WORKSPACE/store/binary-assets
-        rm -rf $CLOUDBEES_WORKSPACE/store/request
+        if [ -d "$CLOUDBEES_WORKSPACE/store" ]; then
+          find $CLOUDBEES_WORKSPACE/store -mindepth 2 -maxdepth 2 \
+            -type d ! -name "discovered-profile-findings" \
+            -exec rm -rf {} +
+          rm -rf $CLOUDBEES_WORKSPACE/store/binary-assets
+          rm -rf $CLOUDBEES_WORKSPACE/store/request
+        fi
 
     - name: Generate reference files
       uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:9b7088fcf5c8b127bc33b3caf9ed24a0124fe4e8


### PR DESCRIPTION
This pull request makes a minor improvement to the cleanup logic in the `action.yml` workflow. The change ensures that cleanup commands are only executed if the `$CLOUDBEES_WORKSPACE/store` directory exists, preventing potential errors if the directory is missing.

- Added a conditional check to execute cleanup commands only when the `$CLOUDBEES_WORKSPACE/store` directory exists in the workflow script (`action.yml`).